### PR TITLE
Use Java 21 in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,4 +22,9 @@ jobs:
       build-wrapper-macosx-x86 --out-dir build_wrapper_output_directory xcodebuild
     workingDirectory: .
     displayName: Build in build-wrapper
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: '21'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
   - task: SonarCloudAnalyze@1


### PR DESCRIPTION
## Summary
- run the Sonar analysis step with Java 21

## Validation
- Parsed the changed YAML with Python
- git diff --check

The current Sonar scanner no longer supports Java 17.

## Fork PR CI note

The Azure pipeline check is expected to fail for this PR because it originates from a fork. Azure DevOps skips `SonarCloudPrepare`, which references the protected SonarCloud service endpoint, so `SonarCloudAnalyze` subsequently reports that its variables are missing. After merge, the `main` build can access the service connection and should validate the Java 21 change successfully.